### PR TITLE
cld setup gcloud update

### DIFF
--- a/client/fmcmds/setup_gcloud.py
+++ b/client/fmcmds/setup_gcloud.py
@@ -10,7 +10,7 @@ class GCloudSetup(Command):
         os.system("gunzip google-cloud-sdk-178.0.0-linux-x86_64.tar.gz")
         os.system("tar -xvf google-cloud-sdk-178.0.0-linux-x86_64.tar")
         os.system("./google-cloud-sdk/install.sh --quiet")
-        #os.system("./google-cloud-sdk/bin/gcloud auth login")
+        os.system("./google-cloud-sdk/bin/gcloud auth login")
         os.system("./google-cloud-sdk/bin/gcloud auth application-default login")
         os.system("rm -rf google-cloud-sdk")
         os.system("rm google-cloud-sdk-178.0.0-linux-x86_64.tar")


### PR DESCRIPTION
- gcloud auth login -> required for google-auth library
- gcloud auth application-default login -> required for gcloud sdk

Internally we use both