### PR TITLE
AWS: Timeout removal and ensuring transactional semantics

### DIFF
--- a/server/server_plugins/aws/aws_helper.py
+++ b/server/server_plugins/aws/aws_helper.py
@@ -146,6 +146,7 @@ class AWSHelper(object):
             security_group_id = response['GroupId']
         except Exception as e:
             fmlogger.error("Encountered exception in creating security group %s" % e)
+            raise e
 
         return security_group_id
 


### PR DESCRIPTION
Timeouts:
- Removing timeouts as it is not possible for CloudARK to
  know the user's setup where CloudARK will be installed.
  For regions that are really slow, CloudARK may timeout
  when the cloud resource is still being created. So such
  timeouts cause CloudARK to be *less* robust than what the
  cloud actually is. So timeouts are bad! Removing them.

Transactional semantics:
- If a cloud resource creation request fails, CloudARK should
  cleanup all the cloud resources that is has created till that
  point. Added this support for ecs.py and rds_handler.py.
  Eventually we should consider developing a reusable library to
  seamlessly handle such cleanups to enfore transactional semantics
  of different cloud resource operations.