### PR TITLE
Status checks for ECS cluster create and Policy checks

### DIFF
--- a/server/aws_handler.py
+++ b/server/aws_handler.py
@@ -137,3 +137,7 @@ class AWSHandler(object):
             if name == coe_type:
                 log_lines = ext.obj.get_logs(app_id, app_info)
         return log_lines
+
+    def check_permissions(self):
+        permission_list = AWSHandler.awshelper.get_attached_policies()
+        return permission_list

--- a/server/common/common_functions.py
+++ b/server/common/common_functions.py
@@ -13,6 +13,7 @@ import fm_logger
 from server.dbmodule.objects import app as app_db
 from server.dbmodule.objects import environment as env_db
 from server.dbmodule.objects import resource as res_db
+from __builtin__ import False
 
 home_dir = expanduser("~")
 
@@ -342,3 +343,31 @@ def get_cont_names(doc, cont_name_set):
     except Exception as e:
         fmlogging.error(str(e))
     return cont_name_set
+
+def are_new_log_lines(logs, log_lines_list):
+    new_lines_found = False
+
+    new_lines = []
+    lines = logs[0].split("\n")
+    for line in lines:
+        if line not in log_lines_list:
+            new_lines.append(line)
+
+    if new_lines:
+        new_lines_found = True
+    return new_lines_found, new_lines
+
+def is_error_in_log_lines(logs):
+    error_found = False
+    error_line = ''
+    lines = logs[0].split('\n')
+    for line in lines:
+        if ( line.lower().find("error") >= 0 or
+             line.lower().find("failure") >= 0 or
+             line.lower().find("failed") >= 0 or
+             line.lower().find("rollback") >= 0):
+            error_found = True
+            error_line = line
+            break
+
+    return error_found, error_line

--- a/server/environment_handler.py
+++ b/server/environment_handler.py
@@ -176,3 +176,7 @@ class EnvironmentHandler(threading.Thread):
                                                                                                     resource,
                                                                                                     command_string)
         return command_output
+
+    def check_permissions(self):
+        permission_list = aws_handler.AWSHandler().check_permissions()
+        return permission_list

--- a/server/fmserver.py
+++ b/server/fmserver.py
@@ -483,7 +483,12 @@ environment_name)
                 environment_info['name'] = environment_name
 
                 environment_info['location'] = env_location
-                request_handler_thread = environment_handler.EnvironmentHandler(env_id, environment_def, environment_info, action='create')
+                request_handler_thread = environment_handler.EnvironmentHandler(env_id, environment_def,
+                                                                                environment_info, action='create')
+
+                # Check permissions here
+                # permission_list = request_handler_thread.check_permissions()
+
                 thread.start_new_thread(start_thread, (request_handler_thread, ))
 
                 response.headers['location'] = ('/environments/{env_name}').format(env_name=environment_name)

--- a/server/server_plugins/aws/aws_helper.py
+++ b/server/server_plugins/aws/aws_helper.py
@@ -412,3 +412,42 @@ class AWSHelper(object):
                 type = value
 
         return type
+
+    def get_attached_policies(self):
+        attached_policies_list = []
+
+        resp1 = self.iam_client.get_account_authorization_details()
+
+        user_list = resp1['UserDetailList']
+        if user_list:
+            user_policy_list = resp1['UserDetailList'][0]['UserPolicyList']
+            for policy in user_policy_list:
+                #print(policy['PolicyName'])
+                attached_policies_list.append(policy['PolicyName'])
+
+            attached_managed_policy_list = resp1['UserDetailList'][0]['AttachedManagedPolicies']
+            for policy in attached_managed_policy_list:
+                attached_policies_list.append(policy['PolicyName'])
+
+        group_detail_list = resp1['GroupDetailList']
+        if group_detail_list:
+            group_policy_list = group_detail_list[0]['GroupPolicyList']
+            for policy in group_policy_list:
+                attached_policies_list.append(policy['PolicyName'])
+
+            attached_managed_policy_list = group_detail_list[0]['AttachedManagedPolicies']
+            for policy in attached_managed_policy_list:
+                attached_policies_list.append(policy['PolicyName'])
+
+        role_detail_list = resp1['RoleDetailList']
+        if role_detail_list:
+            for role in role_detail_list:
+                role_policy_list = role['RolePolicyList']
+                for policy in role_policy_list:
+                    attached_policies_list.append(policy['PolicyName'])
+
+                attached_managed_policy_list = role['AttachedManagedPolicies']
+                for policy in attached_managed_policy_list:
+                    attached_policies_list.append(policy['PolicyName'])
+
+        return attached_policies_list


### PR DESCRIPTION
- Added status checkes for ECS cluster create
- Started adding checking for whether cld has appropriate
  policies for creating the environment and deploying application
  containers.
  - First step is to get all the effective policies/permissions
    for cld. This patch does this for AWS